### PR TITLE
feat(duckdb): 初始化 DuckDB Starter 模块

### DIFF
--- a/bubble-dependencies/pom.xml
+++ b/bubble-dependencies/pom.xml
@@ -57,6 +57,7 @@
         <forest.version>1.8.0</forest.version>
         <java-diff-utils.version>4.15</java-diff-utils.version>
         <liteflow.version>2.15.2</liteflow.version>
+        <duckdb.version>1.4.2.0</duckdb.version>
     </properties>
 
     <dependencyManagement>
@@ -113,6 +114,12 @@
 
             <dependency>
                 <groupId>cn.fxbin.bubble</groupId>
+                <artifactId>bubble-starter-data-duckdb</artifactId>
+                <version>2.0.0.BUILD-SNAPSHOT</version>
+            </dependency>
+
+            <dependency>
+                <groupId>cn.fxbin.bubble</groupId>
                 <artifactId>bubble-starter-lock</artifactId>
                 <version>2.0.0.BUILD-SNAPSHOT</version>
             </dependency>
@@ -120,12 +127,6 @@
             <dependency>
                 <groupId>cn.fxbin.bubble</groupId>
                 <artifactId>bubble-starter-excel</artifactId>
-                <version>2.0.0.BUILD-SNAPSHOT</version>
-            </dependency>
-
-            <dependency>
-                <groupId>cn.fxbin.bubble</groupId>
-                <artifactId>bubble-starter-flow</artifactId>
                 <version>2.0.0.BUILD-SNAPSHOT</version>
             </dependency>
 
@@ -525,9 +526,6 @@
                 <artifactId>forest-spring-boot3-starter</artifactId>
                 <version>${forest.version}</version>
             </dependency>
-<<<<<<< HEAD
-            
-=======
 
             <!-- duckdb -->
             <dependency>
@@ -536,7 +534,6 @@
                 <version>${duckdb.version}</version>
             </dependency>
 
->>>>>>> df135a0 (feat(bubble-dependencies): 引入liteflow规则引擎依赖)
             <!-- java-diff-utils -->
             <dependency>
                 <groupId>io.github.java-diff-utils</groupId>

--- a/bubble-starters/bubble-starter-data-duckdb/pom.xml
+++ b/bubble-starters/bubble-starter-data-duckdb/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>cn.fxbin.bubble</groupId>
+        <artifactId>bubble-starters</artifactId>
+        <version>2.0.0.BUILD-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bubble-starter-data-duckdb</artifactId>
+    <name>Bubble Starter Data DuckDB</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>cn.fxbin.bubble</groupId>
+            <artifactId>bubble-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.duckdb</groupId>
+            <artifactId>duckdb_jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.dreamlu</groupId>
+            <artifactId>mica-auto</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>cn.fxbin.bubble</groupId>
+            <artifactId>bubble-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/DuckDbOperations.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/DuckDbOperations.java
@@ -1,0 +1,200 @@
+package cn.fxbin.bubble.data.duckdb;
+
+import cn.fxbin.bubble.data.duckdb.core.DuckDbIngester;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbManager;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbTemplate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.Assert;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DuckDB 统一客户端入口
+ *
+ * <p>
+ * 提供对默认 DuckDB 实例的直接访问，以及对动态 DuckDB 文件的管理。
+ * 采用了外观模式（Facade Pattern），将 DuckDbTemplate、DuckDbIngester 和 DuckDbManager 的功能统一暴露。
+ * </p>
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 16:30
+ */
+@Slf4j
+public class DuckDbOperations {
+
+    private final DuckDbTemplate defaultTemplate;
+    private final DuckDbManager manager;
+    private final DuckDbIngester defaultIngester;
+
+    public DuckDbOperations(DuckDbTemplate defaultTemplate, DuckDbManager manager, DuckDbIngester defaultIngester) {
+        Assert.notNull(defaultTemplate, "Default DuckDbTemplate must not be null");
+        Assert.notNull(manager, "DuckDbManager must not be null");
+        Assert.notNull(defaultIngester, "Default DuckDbIngester must not be null");
+        this.defaultTemplate = defaultTemplate;
+        this.manager = manager;
+        this.defaultIngester = defaultIngester;
+    }
+
+    // =================================================================================================================
+    // 基础查询操作 (Delegate to defaultTemplate)
+    // =================================================================================================================
+
+    /**
+     * 获取默认的 DuckDbTemplate。
+     *
+     * @return 默认模板实例。
+     */
+    public DuckDbTemplate template() {
+        return defaultTemplate;
+    }
+
+    /**
+     * 在默认数据库上执行 SQL 查询。
+     *
+     * @param sql SQL 查询语句。
+     * @return 结果列表（Map）。
+     */
+    public List<Map<String, Object>> query(String sql) {
+        return defaultTemplate.queryForList(sql);
+    }
+
+    /**
+     * 在默认数据库上执行 SQL 查询，并返回指定类型的对象列表。
+     *
+     * @param sql  SQL 查询语句。
+     * @param type 结果类型。
+     * @param <T>  泛型类型。
+     * @return 对象列表。
+     */
+    public <T> List<T> query(String sql, Class<T> type) {
+        return defaultTemplate.queryForList(sql, type);
+    }
+
+    /**
+     * 在默认数据库上执行 SQL 查询，并返回单个对象。
+     *
+     * @param sql  SQL 查询语句。
+     * @param type 结果类型。
+     * @param <T>  泛型类型。
+     * @return 单个对象，如果未找到则为 null。
+     */
+    public <T> T queryForObject(String sql, Class<T> type) {
+        try {
+            return defaultTemplate.queryForObject(sql, type);
+        } catch (org.springframework.dao.EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 获取表行数统计。
+     *
+     * @param tableName 表名。
+     * @return 行数。
+     */
+    public Long count(String tableName) {
+        DuckDbTemplate.validateTableName(tableName);
+        String sql = "SELECT count(*) FROM " + tableName;
+        return defaultTemplate.queryForObject(sql, Long.class);
+    }
+
+    /**
+     * 在默认数据库上执行 SQL 语句（DDL/DML）。
+     *
+     * @param sql SQL 语句。
+     */
+    public void execute(String sql) {
+        defaultTemplate.execute(sql);
+    }
+
+    // =================================================================================================================
+    // 数据导入导出 (Ingestion & Parquet)
+    // =================================================================================================================
+
+    /**
+     * 向默认数据库追加数据（使用 Appender，高性能）。
+     *
+     * @param tableName    表名。
+     * @param dataIterator 数据迭代器。
+     */
+    public void ingest(String tableName, Iterator<Object[]> dataIterator) {
+        defaultIngester.ingest(tableName, dataIterator);
+    }
+
+    /**
+     * 向默认数据库追加数据（列表方式）。
+     *
+     * @param tableName 表名。
+     * @param rows      数据行。
+     */
+    public void append(String tableName, List<Object[]> rows) {
+        defaultTemplate.append(tableName, rows);
+    }
+
+    /**
+     * 将 Parquet 文件导入到表中。
+     *
+     * @param tableName   目标表名（将被创建）。
+     * @param parquetPath Parquet 文件的路径。
+     */
+    public void importParquet(String tableName, String parquetPath) {
+        defaultTemplate.importParquet(tableName, parquetPath);
+    }
+
+    /**
+     * 将表（或查询结果）导出为 Parquet 文件。
+     *
+     * @param tableNameOrQuery 表名或 SELECT 查询。
+     * @param outputPath       Parquet 文件的输出路径。
+     */
+    public void exportParquet(String tableNameOrQuery, String outputPath) {
+        defaultTemplate.exportParquet(tableNameOrQuery, outputPath);
+    }
+
+    // =================================================================================================================
+    // 动态实例操作 (Delegate to manager)
+    // =================================================================================================================
+
+    /**
+     * 连接到指定的 DuckDB 文件。
+     *
+     * @param filePath 数据库文件路径。
+     * @return 该文件的 DuckDbTemplate 实例。
+     */
+    public DuckDbTemplate connect(String filePath) {
+        return manager.getTemplate(filePath);
+    }
+
+    /**
+     * 以指定模式连接到指定的 DuckDB 文件。
+     *
+     * @param filePath 数据库文件路径。
+     * @param readOnly 是否只读。
+     * @return 该文件的 DuckDbTemplate 实例。
+     */
+    public DuckDbTemplate connect(String filePath, boolean readOnly) {
+        return manager.getTemplate(filePath, readOnly);
+    }
+
+    /**
+     * 关闭指定文件的连接。
+     *
+     * @param filePath 数据库文件路径。
+     */
+    public void close(String filePath) {
+        manager.close(filePath, false);
+        manager.close(filePath, true); // 尝试关闭只读连接
+    }
+
+    /**
+     * 获取底层的 DuckDbManager。
+     *
+     * @return 管理器实例。
+     */
+    public DuckDbManager manager() {
+        return manager;
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/autoconfigure/DuckDbAutoConfiguration.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/autoconfigure/DuckDbAutoConfiguration.java
@@ -1,0 +1,87 @@
+package cn.fxbin.bubble.data.duckdb.autoconfigure;
+
+import cn.fxbin.bubble.data.duckdb.DuckDbOperations;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbConnectionFactory;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbIngester;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbManager;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbTemplate;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.duckdb.DuckDBDriver;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import javax.sql.DataSource;
+
+/**
+ * DuckDB 自动配置
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 11:42
+ */
+@Slf4j
+@AutoConfiguration
+@ConditionalOnClass({DuckDBDriver.class, DataSource.class})
+@EnableConfigurationProperties(DuckDbProperties.class)
+@ConditionalOnProperty(prefix = "dm.data.duckdb", name = "enabled", havingValue = "true", matchIfMissing = true)
+@AutoConfigureAfter(DataSourceAutoConfiguration.class)
+public class DuckDbAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DuckDbConnectionFactory duckDbConnectionFactory(DuckDbProperties properties) {
+        return new DuckDbConnectionFactory(properties);
+    }
+
+    /**
+     * 定义 DuckDB 专用数据源
+     * <p>
+     * 注意：这里不使用 @Primary，也不使用 @ConditionalOnMissingBean(DataSource.class)，
+     * 以确保它能作为“第二数据源”与主业务库（如 MySQL）共存。
+     * </p>
+     */
+    @Bean("duckDbDataSource")
+    public DataSource duckDbDataSource(DuckDbConnectionFactory connectionFactory, DuckDbProperties properties) {
+        if (properties.getMode() == DuckDbProperties.Mode.FILE && !properties.isReadOnly()) {
+            log.warn("DuckDB 配置为 FILE 模式，具有 READ_WRITE 访问权限。" +
+                    "确保没有其他进程正在访问 '{}'。DuckDB 强制执行单一写入者策略。", properties.getFilePath());
+        }
+
+        HikariDataSource dataSource = connectionFactory.createDefaultDataSource();
+        log.info("DuckDB 数据源已初始化: {}", dataSource.getJdbcUrl());
+        return dataSource;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DuckDbTemplate duckDbTemplate(@Qualifier("duckDbDataSource") DataSource dataSource) {
+        return new DuckDbTemplate(dataSource);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DuckDbManager duckDbManager(DuckDbProperties properties) {
+        return new DuckDbManager(properties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DuckDbIngester duckDbIngester(@Qualifier("duckDbDataSource") DataSource dataSource) {
+        return new DuckDbIngester(dataSource);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DuckDbOperations duckDbOperations(DuckDbTemplate duckDbTemplate, DuckDbManager duckDbManager, DuckDbIngester duckDbIngester) {
+        return new DuckDbOperations(duckDbTemplate, duckDbManager, duckDbIngester);
+    }
+
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/autoconfigure/DuckDbProperties.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/autoconfigure/DuckDbProperties.java
@@ -1,0 +1,127 @@
+package cn.fxbin.bubble.data.duckdb.autoconfigure;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DuckDB 配置属性
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 11:35
+ */
+@Data
+@ConfigurationProperties(prefix = "dm.data.duckdb")
+public class DuckDbProperties {
+
+    /**
+     * 是否启用 DuckDB 自动配置。
+     */
+    private boolean enabled = true;
+
+    /**
+     * 数据库模式：内存模式或文件模式。
+     */
+    private Mode mode = Mode.FILE;
+
+    /**
+     * 数据库文件路径（当模式为 FILE 时必需）。
+     * 如果未指定，默认为工作目录中的 "duckdb_store.db"。
+     */
+    private String filePath = "duckdb_store.db";
+
+    /**
+     * 是否以只读模式打开数据库。
+     * 在多进程场景中，当此实例为读取者时很有用。
+     */
+    private boolean readOnly = false;
+
+    /**
+     * 自定义 JDBC URL。如果设置，将覆盖 mode 和 filePath 设置。
+     */
+    private String url;
+
+    /**
+     * HikariCP 的最大连接池大小。
+     * 对于内存中的 DuckDB，通常 1 个连接就足够了，但它支持并发连接。
+     * 对于基于文件的数据库，它也支持来自同一进程的并发连接。
+     */
+    private Integer maximumPoolSize;
+
+    /**
+     * DuckDB 特定配置选项。
+     * DuckDB 配置的键值对（例如：threads、max_memory）。
+     */
+    private Map<String, String> config = new HashMap<>();
+
+    /**
+     * 要加载的 DuckDB 扩展列表（例如：parquet, httpfs, json）。
+     */
+    private List<String> extensions = new ArrayList<>();
+
+    /**
+     * 是否自动安装扩展。
+     * 如果为 true，将尝试运行 "INSTALL extension_name"。
+     * 如果为 false，则仅运行 "LOAD extension_name"。
+     */
+    private boolean autoInstallExtensions = true;
+
+    /**
+     * 自定义扩展仓库 URL。
+     * 用于内网环境，指向托管 DuckDB 扩展的 HTTP 服务器。
+     * 对应 SQL: SET custom_extension_repository = '...';
+     */
+    private String customExtensionRepository;
+
+    /**
+     * 本地扩展目录路径。
+     * 如果设置，且 autoInstallExtensions 为 true，将尝试从此目录安装扩展。
+     * 文件名应为 {extension_name}.duckdb_extension。
+     * 对应 SQL: INSTALL 'path/to/extension.duckdb_extension';
+     */
+    private String localExtensionDirectory;
+
+    /**
+     * 是否允许加载未签名的扩展。
+     * 加载本地或自定义仓库的扩展时通常需要设置为 true。
+     * 对应 SQL: SET allow_unsigned_extensions = true;
+     */
+    private boolean allowUnsignedExtensions = false;
+
+    /**
+     * 临时文件目录 (temp_directory)
+     * 用于溢出到磁盘时的临时存储。建议指向高速磁盘（如 NVMe SSD）。
+     */
+    private String tempDirectory;
+
+    /**
+     * 最大内存限制 (memory_limit)
+     * 例如: '10GB', '2GB'
+     * 默认为 '2GB' (默认 1GB 在大数据量 Group By/Sort 时可能 OOM，提升至 2GB)
+     */
+    private String memoryLimit = "2GB";
+
+    /**
+     * 线程数 (threads)
+     * 默认为 CPU 核心数。
+     */
+    private String threads = String.valueOf(Runtime.getRuntime().availableProcessors());
+
+    public enum Mode {
+        /**
+         * 内存数据库。进程退出时数据将丢失。
+         */
+        MEMORY,
+
+        /**
+         * 基于文件的数据库。数据将被持久化。
+         */
+        FILE
+    }
+
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/DuckDbConnectionFactory.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/DuckDbConnectionFactory.java
@@ -1,0 +1,226 @@
+package cn.fxbin.bubble.data.duckdb.core;
+
+import cn.fxbin.bubble.data.duckdb.autoconfigure.DuckDbProperties;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.duckdb.DuckDBDriver;
+import org.springframework.util.StringUtils;
+
+import javax.sql.DataSource;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * DuckDB 连接工厂
+ *
+ * <p>
+ * 用于为 DuckDB 创建 HikariDataSource 实例的工厂。
+ * </p>
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 15:12
+ */
+@Slf4j
+public class DuckDbConnectionFactory {
+
+    private final DuckDbProperties defaultProperties;
+
+    public DuckDbConnectionFactory(DuckDbProperties defaultProperties) {
+        this.defaultProperties = defaultProperties;
+    }
+
+    /**
+     * 根据默认属性创建主数据源。
+     *
+     * @return 配置好的 HikariDataSource。
+     */
+    public HikariDataSource createDefaultDataSource() {
+        String jdbcUrl;
+        if (StringUtils.hasText(defaultProperties.getUrl())) {
+            jdbcUrl = defaultProperties.getUrl();
+        } else {
+            StringBuilder urlBuilder = new StringBuilder("jdbc:duckdb:");
+            
+            if (defaultProperties.getMode() == DuckDbProperties.Mode.FILE) {
+                if (!StringUtils.hasText(defaultProperties.getFilePath())) {
+                    throw new IllegalArgumentException("在 FILE 模式下必须提供 DuckDB filePath。");
+                }
+                urlBuilder.append(defaultProperties.getFilePath());
+            }
+            
+            // 添加只读标志
+            if (defaultProperties.isReadOnly()) {
+                urlBuilder.append("?duckdb.read_only=true");
+            }
+            
+            jdbcUrl = urlBuilder.toString();
+        }
+        
+        HikariDataSource dataSource = createBaseDataSource(jdbcUrl);
+        dataSource.setPoolName("DuckDB-HikariPool");
+        
+        // 如果未指定，保留 Hikari 的默认值
+        if (defaultProperties.getMaximumPoolSize() != null) {
+            dataSource.setMaximumPoolSize(defaultProperties.getMaximumPoolSize());
+        }
+
+        // 初始化扩展
+        initializeExtensions(dataSource);
+
+        return dataSource;
+    }
+
+    /**
+     * 为给定路径和模式创建新的数据源。
+     *
+     * @param filePath DuckDB 文件的路径。
+     * @param readOnly 是否以只读模式打开。
+     * @return 配置好的 HikariDataSource。
+     */
+    public HikariDataSource createDataSource(String filePath, boolean readOnly) {
+        StringBuilder urlBuilder = new StringBuilder("jdbc:duckdb:");
+        urlBuilder.append(filePath);
+        
+        // 添加只读标志
+        if (readOnly) {
+            urlBuilder.append("?duckdb.read_only=true");
+        }
+        
+        HikariDataSource dataSource = createBaseDataSource(urlBuilder.toString());
+        
+        // 动态实例通常不需要大的连接池。
+        // 如果用户没有为动态池指定全局默认值，则使用 1 或 2。
+        Integer poolSize = defaultProperties.getMaximumPoolSize();
+        dataSource.setMaximumPoolSize(poolSize != null ? poolSize : 2); 
+        
+        dataSource.setPoolName("DuckDB-Dynamic-" + filePath.hashCode());
+
+        // 初始化扩展
+        initializeExtensions(dataSource);
+        
+        return dataSource;
+    }
+
+    private HikariDataSource createBaseDataSource(String jdbcUrl) {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setDriverClassName(DuckDBDriver.class.getName());
+        dataSource.setJdbcUrl(jdbcUrl);
+
+        // 1. 应用核心性能配置 (通过 DataSource 属性传递给驱动，确保对所有连接生效)
+        if (StringUtils.hasText(defaultProperties.getTempDirectory())) {
+            dataSource.addDataSourceProperty("temp_directory", defaultProperties.getTempDirectory());
+        }
+        if (StringUtils.hasText(defaultProperties.getMemoryLimit())) {
+            dataSource.addDataSourceProperty("memory_limit", defaultProperties.getMemoryLimit());
+        }
+        if (StringUtils.hasText(defaultProperties.getThreads())) {
+            dataSource.addDataSourceProperty("threads", defaultProperties.getThreads());
+        }
+
+        // 默认禁用插入顺序保留，以减少内存压力 (针对大数据量导入/查询)
+        dataSource.addDataSourceProperty("preserve_insertion_order", "false");
+
+        // 2. 应用扩展相关配置
+        if (defaultProperties.isAllowUnsignedExtensions()) {
+            dataSource.addDataSourceProperty("allow_unsigned_extensions", "true");
+        }
+        if (StringUtils.hasText(defaultProperties.getCustomExtensionRepository())) {
+            dataSource.addDataSourceProperty("custom_extension_repository", defaultProperties.getCustomExtensionRepository());
+        }
+
+        // 3. 应用自定义配置
+        if (defaultProperties.getConfig() != null) {
+            defaultProperties.getConfig().forEach(dataSource::addDataSourceProperty);
+        }
+
+        dataSource.setConnectionTestQuery("SELECT 1");
+
+        String initSql = buildConnectionInitSql();
+        if (StringUtils.hasText(initSql)) {
+            dataSource.setConnectionInitSql(initSql);
+        }
+        return dataSource;
+    }
+
+    private String buildConnectionInitSql() {
+        if (defaultProperties.getExtensions() == null || defaultProperties.getExtensions().isEmpty()) {
+            return null;
+        }
+
+        StringBuilder sql = new StringBuilder();
+        for (String ext : defaultProperties.getExtensions()) {
+            String safeExt = validateExtensionName(ext);
+            sql.append("LOAD ").append(safeExt).append("; ");
+        }
+        return sql.toString().trim();
+    }
+
+    private void initializeExtensions(DataSource dataSource) {
+        // 扩展的安装只需执行一次 (全局)
+        if (defaultProperties.getExtensions() == null || defaultProperties.getExtensions().isEmpty()) {
+            return;
+        }
+
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement()) {
+
+            // 安装并加载扩展
+            for (String ext: defaultProperties.getExtensions()) {
+                String safeExt = validateExtensionName(ext);
+                if (defaultProperties.isAutoInstallExtensions()) {
+                    installExtension(stmt, safeExt);
+                }
+                
+                log.info("Loading DuckDB extension: {}", safeExt);
+                stmt.execute("LOAD " + safeExt);
+            }
+        } catch (SQLException e) {
+            log.error("Failed to initialize DuckDB extensions", e);
+            throw new RuntimeException("Failed to initialize DuckDB extensions", e);
+        }
+    }
+
+    private void installExtension(Statement stmt, String ext) {
+        String installCmd;
+        
+        // 检查是否配置了本地扩展目录
+        if (StringUtils.hasText(defaultProperties.getLocalExtensionDirectory())) {
+            // 假设文件名格式为 name.duckdb_extension
+            // 注意：需要处理路径分隔符
+            String directory = defaultProperties.getLocalExtensionDirectory();
+            String localPath = Path.of(directory, ext + ".duckdb_extension").toString();
+            log.info("Installing DuckDB extension from local path: {}", localPath);
+            installCmd = "INSTALL '" + escapeSingleQuotes(localPath) + "'";
+        } else {
+            log.info("Installing DuckDB extension: {}", ext);
+            installCmd = "INSTALL " + ext;
+        }
+
+        try {
+            stmt.execute(installCmd);
+        } catch (SQLException e) {
+            // 某些环境可能无法联网，或者扩展已预装。
+            // 如果安装失败，我们记录警告但尝试继续加载，因为可能已经存在。
+            log.warn("Failed to install DuckDB extension: {}. It might be already installed or not found. Error: {}", ext, e.getMessage());
+        }
+    }
+
+    private static String validateExtensionName(String extensionName) {
+        if (!StringUtils.hasText(extensionName)) {
+            throw new IllegalArgumentException("扩展名不能为空");
+        }
+
+        String trimmed = extensionName.trim();
+        if (!trimmed.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("无效的扩展名：" + extensionName);
+        }
+        return trimmed;
+    }
+
+    private static String escapeSingleQuotes(String value) {
+        return value.replace("'", "''");
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/DuckDbIngester.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/DuckDbIngester.java
@@ -1,0 +1,153 @@
+package cn.fxbin.bubble.data.duckdb.core;
+
+import cn.fxbin.bubble.data.duckdb.core.handler.TypeHandler;
+import cn.fxbin.bubble.data.duckdb.core.handler.TypeHandlerFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.duckdb.DuckDBAppender;
+import org.duckdb.DuckDBConnection;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DuckDB 数据摄取器
+ *
+ * <p>
+ * 使用 DuckDB Appender 的高性能数据摄取工具。
+ * 适用于将大型数据集（例如从 IoTDB）传输到 DuckDB。
+ * </p>
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 15:05
+ */
+@Slf4j
+public class DuckDbIngester {
+
+    private final DataSource dataSource;
+
+    public DuckDbIngester(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    /**
+     * 将数据列表追加到指定的 DuckDB 表中。
+     *
+     * @param tableName 目标表名。
+     * @param rows      要插入的数据行列表（对象数组）。
+     */
+    public void append(String tableName, List<Object[]> rows) {
+        ingest(tableName, rows.iterator());
+    }
+
+    /**
+     * 将 Map 列表数据追加到指定的 DuckDB 表中。
+     *
+     * @param tableName 目标表名。
+     * @param rows      要插入的数据行列表（Map）。
+     * @param columns   列名列表（有序），必须与数据库表列顺序一致。
+     */
+    public void appendMaps(String tableName, List<Map<String, Object>> rows, List<String> columns) {
+        Iterator<Object[]> iterator = new Iterator<>() {
+            private final Iterator<Map<String, Object>> mapIterator = rows.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return mapIterator.hasNext();
+            }
+
+            @Override
+            public Object[] next() {
+                Map<String, Object> map = mapIterator.next();
+                Object[] row = new Object[columns.size()];
+                for (int i = 0; i < columns.size(); i++) {
+                    row[i] = map.get(columns.get(i));
+                }
+                return row;
+            }
+        };
+        ingest(tableName, iterator);
+    }
+
+    /**
+     * 使用 DuckDB Appender 摄取数据。
+     *
+     * @param tableName    目标表名。
+     * @param dataIterator 数据行迭代器（对象数组）。
+     */
+    public void ingest(String tableName, Iterator<Object[]> dataIterator) {
+        ingest(tableName, dataIterator, 10000); // 默认批次日志大小
+    }
+
+    /**
+     * 使用 DuckDB Appender 摄取数据，并记录进度。
+     *
+     * @param tableName    目标表名。
+     * @param dataIterator 数据行迭代器。
+     * @param logInterval  每隔 N 行记录一次进度。
+     */
+    public void ingest(String tableName, Iterator<Object[]> dataIterator, int logInterval) {
+        DuckDbTemplate.validateTableName(tableName);
+        if (dataIterator == null) {
+            throw new IllegalArgumentException("dataIterator 不能为空");
+        }
+        if (logInterval <= 0) {
+            throw new IllegalArgumentException("logInterval 必须大于 0");
+        }
+        try (Connection conn = dataSource.getConnection()) {
+            
+            // 1. 获取列元数据并预计算 TypeHandlers
+            int[] columnTypes = getColumnTypes(conn, tableName);
+            TypeHandler[] handlers = new TypeHandler[columnTypes.length];
+            for (int i = 0; i < columnTypes.length; i++) {
+                handlers[i] = TypeHandlerFactory.getHandler(columnTypes[i]);
+            }
+            
+            // 2. 解包以获取原生的 DuckDBConnection
+            DuckDBConnection duckDBConn = conn.unwrap(DuckDBConnection.class);
+            
+            try (DuckDBAppender appender = duckDBConn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, tableName)) {
+                long count = 0;
+                while (dataIterator.hasNext()) {
+                    Object[] row = dataIterator.next();
+                    appender.beginRow();
+                    
+                    if (row.length != handlers.length) {
+                         throw new SQLException("数据行长度 (" + row.length + ") 与表列数 (" + handlers.length + ") 不匹配");
+                    }
+
+                    for (int i = 0; i < row.length; i++) {
+                        // 使用策略模式：循环中不再进行 instanceof 检查
+                        handlers[i].append(appender, row[i]);
+                    }
+                    appender.endRow();
+                    
+                    count++;
+                    if (count % logInterval == 0) {
+                        log.info("已摄取 {} 行到 {}", count, tableName);
+                    }
+                }
+                log.info("摄取完成。总行数：{}", count);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("摄取数据到 DuckDB 失败", e);
+        }
+    }
+
+    private int[] getColumnTypes(Connection conn, String tableName) throws SQLException {
+        DuckDbTemplate.validateTableName(tableName);
+        try (Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT * FROM " + tableName + " LIMIT 0")) {
+            ResultSetMetaData meta = rs.getMetaData();
+            int count = meta.getColumnCount();
+            int[] types = new int[count];
+            for (int i = 0; i < count; i++) {
+                types[i] = meta.getColumnType(i + 1);
+            }
+            return types;
+        }
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/DuckDbManager.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/DuckDbManager.java
@@ -1,0 +1,133 @@
+package cn.fxbin.bubble.data.duckdb.core;
+
+import cn.fxbin.bubble.data.duckdb.autoconfigure.DuckDbProperties;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * DuckDB 管理器
+ *
+ * <p>
+ * 管理动态 DuckDB 数据源和模板。
+ * 允许在运行时为特定文件创建和访问 DuckDB 实例。
+ * </p>
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 14:15
+ */
+@Slf4j
+public class DuckDbManager implements Closeable {
+
+    private final DuckDbConnectionFactory connectionFactory;
+    
+    /**
+     * 数据源缓存：键是文件路径（或 ID），值是数据源。
+     */
+    private final Map<String, HikariDataSource> dataSourceCache = new ConcurrentHashMap<>();
+    
+    /**
+     * 模板缓存：键是文件路径（或 ID），值是 DuckDbTemplate。
+     */
+    private final Map<String, DuckDbTemplate> templateCache = new ConcurrentHashMap<>();
+
+    public DuckDbManager(DuckDbProperties properties) {
+        this.connectionFactory = new DuckDbConnectionFactory(properties);
+    }
+
+
+    /**
+     * 获取或为指定文件路径创建一个 DuckDbTemplate。
+     * 默认为读写模式。
+     *
+     * @param filePath DuckDB 文件的路径。
+     * @return DuckDbTemplate 实例。
+     */
+    public DuckDbTemplate getTemplate(String filePath) {
+        return getTemplate(filePath, false);
+    }
+
+    /**
+     * 获取或为指定文件路径和特定模式创建一个 DuckDbTemplate。
+     *
+     * @param filePath DuckDB 文件的路径。
+     * @param readOnly 是否以只读模式打开。
+     * @return DuckDbTemplate 实例。
+     */
+    public DuckDbTemplate getTemplate(String filePath, boolean readOnly) {
+        if (!StringUtils.hasText(filePath)) {
+            throw new IllegalArgumentException("文件路径不能为空");
+        }
+        
+        // 如果我们想支持以不同模式打开同一文件，是否应该使用复合键？
+        // 通常，HikariCP 池绑定到一个 URL。
+        // 读写模式 URL：jdbc:duckdb:/path
+        // 只读模式 URL：jdbc:duckdb:/path?duckdb.read_only=true
+        // 所以键应该包含模式。
+        String cacheKey = buildCacheKey(filePath, readOnly);
+
+        return templateCache.computeIfAbsent(cacheKey, k -> {
+            HikariDataSource dataSource = getDataSource(filePath, readOnly);
+            return new DuckDbTemplate(dataSource);
+        });
+    }
+
+    /**
+     * 获取或为指定文件路径创建一个数据源。
+     *
+     * @param filePath DuckDB 文件的路径。
+     * @param readOnly 是否以只读模式打开。
+     * @return HikariDataSource 实例。
+     */
+    public HikariDataSource getDataSource(String filePath, boolean readOnly) {
+        String cacheKey = buildCacheKey(filePath, readOnly);
+        
+        return dataSourceCache.computeIfAbsent(cacheKey, k -> {
+            log.info("为路径创建动态 DuckDB 数据源：{} (只读：{})", filePath, readOnly);
+            return createDataSource(filePath, readOnly);
+        });
+    }
+
+    /**
+     * 关闭并移除指定文件路径的数据源。
+     * 这对于释放文件锁很重要。
+     *
+     * @param filePath DuckDB 文件的路径。
+     * @param readOnly 要关闭的模式。
+     */
+    public void close(String filePath, boolean readOnly) {
+        String cacheKey = buildCacheKey(filePath, readOnly);
+        
+        templateCache.remove(cacheKey);
+        HikariDataSource ds = dataSourceCache.remove(cacheKey);
+        
+        if (ds != null) {
+            log.info("关闭路径的动态 DuckDB 数据源：{}", filePath);
+            ds.close();
+        }
+    }
+
+    /**
+     * 关闭所有动态数据源。
+     */
+    @Override
+    public void close() {
+        log.info("关闭所有动态 DuckDB 数据源...");
+        dataSourceCache.forEach((k, ds) -> ds.close());
+        dataSourceCache.clear();
+        templateCache.clear();
+    }
+
+    private String buildCacheKey(String filePath, boolean readOnly) {
+        return filePath + "::" + (readOnly ? "RO" : "RW");
+    }
+
+    private HikariDataSource createDataSource(String filePath, boolean readOnly) {
+        return connectionFactory.createDataSource(filePath, readOnly);
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/DuckDbTemplate.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/DuckDbTemplate.java
@@ -1,0 +1,144 @@
+package cn.fxbin.bubble.data.duckdb.core;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DuckDB 模板
+ *
+ * <p>
+ * JdbcTemplate 的扩展，提供 DuckDB 特定功能，包括数据导入。
+ * </p>
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 11:38
+ */
+@Slf4j
+public class DuckDbTemplate extends JdbcTemplate {
+
+    private final DuckDbIngester ingester;
+
+    public DuckDbTemplate(DataSource dataSource) {
+        super(dataSource);
+        this.ingester = new DuckDbIngester(dataSource);
+    }
+
+    /**
+     * 将数据追加到指定的 DuckDB 表中。
+     *
+     * @param tableName 目标表名。
+     * @param rows      要插入的数据行列表（对象数组）。
+     */
+    public void append(String tableName, List<Object[]> rows) {
+        ingester.append(tableName, rows);
+    }
+
+    /**
+     * 将数据流追加到指定的 DuckDB 表中（流式处理）。
+     *
+     * @param tableName 目标表名。
+     * @param iterator  要插入的数据行迭代器（对象数组）。
+     */
+    public void append(String tableName, java.util.Iterator<Object[]> iterator) {
+        ingester.ingest(tableName, iterator);
+    }
+
+    /**
+     * 将 Map 列表数据追加到指定的 DuckDB 表中。
+     *
+     * @param tableName 目标表名。
+     * @param rows      要插入的数据行列表（Map）。
+     * @param columns   列名列表（有序）。
+     */
+    public void appendMaps(String tableName, List<Map<String, Object>> rows, List<String> columns) {
+        ingester.appendMaps(tableName, rows, columns);
+    }
+
+    /**
+     * 将 Parquet 文件导入到表中。
+     *
+     * @param tableName 目标表名（将被创建）。
+     * @param parquetPath Parquet 文件的路径。
+     */
+    public void importParquet(String tableName, String parquetPath) {
+        validateTableName(tableName);
+        if (parquetPath == null || parquetPath.isBlank()) {
+            throw new IllegalArgumentException("parquetPath 不能为空");
+        }
+        String sql = String.format("CREATE TABLE %s AS SELECT * FROM read_parquet('%s')", tableName, escapeSingleQuotes(parquetPath));
+        log.info("执行 DuckDB 导入 Parquet：{}", sql);
+        execute(sql);
+    }
+
+    /**
+     * 将表（或查询结果）导出为 Parquet 文件。
+     *
+     * @param tableNameOrQuery 表名或 SELECT 查询。
+     * @param outputPath Parquet 文件的输出路径。
+     */
+    public void exportParquet(String tableNameOrQuery, String outputPath) {
+        if (outputPath == null || outputPath.isBlank()) {
+            throw new IllegalArgumentException("outputPath 不能为空");
+        }
+        String source = tableNameOrQuery.trim().toUpperCase().startsWith("SELECT")
+                ? String.format("(%s)", tableNameOrQuery)
+                : validateTableName(tableNameOrQuery);
+        
+        String sql = String.format("COPY %s TO '%s' (FORMAT PARQUET)", source, escapeSingleQuotes(outputPath));
+        log.info("执行 DuckDB 导出 Parquet：{}", sql);
+        execute(sql);
+    }
+
+    public static String validateTableName(String tableName) {
+        if (tableName == null || !tableName.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("无效的表名：" + tableName);
+        }
+        return tableName;
+    }
+
+    private static String validateIdentifier(String identifier, String fieldName) {
+        if (identifier == null || !identifier.matches("^[a-zA-Z0-9_]+$")) {
+            throw new IllegalArgumentException("无效的" + fieldName + "：" + identifier);
+        }
+        return identifier;
+    }
+
+    private static String escapeSingleQuotes(String value) {
+        return value.replace("'", "''");
+    }
+
+    /**
+     * 附加另一个数据库文件。
+     *
+     * @param dbPath 数据库文件的路径。
+     * @param alias 要使用的别名。
+     */
+    public void attachDatabase(String dbPath, String alias) {
+        if (dbPath == null || dbPath.isBlank()) {
+            throw new IllegalArgumentException("dbPath 不能为空");
+        }
+        validateIdentifier(alias, "别名");
+        String sql = String.format("ATTACH '%s' AS %s", escapeSingleQuotes(dbPath), alias);
+        log.info("执行 DuckDB 附加：{}", sql);
+        execute(sql);
+    }
+    
+    /**
+     * 安装并加载扩展。
+     *
+     * @param extensionName 扩展的名称（例如，'httpfs'、'spatial'）。
+     */
+    public void installAndLoadExtension(String extensionName) {
+        validateIdentifier(extensionName, "扩展名");
+        log.info("安装 DuckDB 扩展：{}", extensionName);
+        execute("INSTALL " + extensionName);
+        log.info("加载 DuckDB 扩展：{}", extensionName);
+        execute("LOAD " + extensionName);
+    }
+
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/handler/TypeHandler.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/handler/TypeHandler.java
@@ -1,0 +1,25 @@
+package cn.fxbin.bubble.data.duckdb.core.handler;
+
+import org.duckdb.DuckDBAppender;
+
+import java.sql.SQLException;
+
+/**
+ * 类型处理器接口
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 15:07
+ */
+public interface TypeHandler {
+
+    /**
+     * 将值附加到 DuckDB Appender
+     *
+     * @param appender DuckDB Appender
+     * @param value    要附加的值
+     * @throws SQLException 如果发生错误
+     */
+    void append(DuckDBAppender appender, Object value) throws SQLException;
+
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/handler/TypeHandlerFactory.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/main/java/cn/fxbin/bubble/data/duckdb/core/handler/TypeHandlerFactory.java
@@ -1,0 +1,125 @@
+package cn.fxbin.bubble.data.duckdb.core.handler;
+
+import cn.fxbin.bubble.core.util.time.DateUtils;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 类型处理器工厂
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 15:08
+ */
+public class TypeHandlerFactory {
+
+    private static final Map<Integer, TypeHandler> HANDLERS = new HashMap<>();
+    private static final TypeHandler DEFAULT_HANDLER = (appender, value) -> appender.append(value == null ? null : value.toString());
+
+    static {
+        register(Types.INTEGER, (appender, value) -> {
+            if (value instanceof Number n) {
+                appender.append(n.intValue());
+            } else {
+                appender.append(value == null ? null : Integer.parseInt(value.toString()));
+            }
+        });
+        
+        register(Types.BIGINT, (appender, value) -> {
+            if (value instanceof Number n) {
+                appender.append(n.longValue());
+            } else {
+                appender.append(value == null ? null : Long.parseLong(value.toString()));
+            }
+        });
+        
+        register(Types.DOUBLE, (appender, value) -> {
+            if (value instanceof Number n) {
+                appender.append(n.doubleValue());
+            } else {
+                appender.append(value == null ? null : Double.parseDouble(value.toString()));
+            }
+        });
+        
+        register(Types.FLOAT, (appender, value) -> {
+            if (value instanceof Number n) {
+                appender.append(n.floatValue());
+            } else {
+                appender.append(value == null ? null : Float.parseFloat(value.toString()));
+            }
+        });
+
+        register(Types.BOOLEAN, (appender, value) -> {
+            if (value instanceof Boolean b) {
+                appender.append(b);
+            } else {
+                appender.append(value == null ? null : Boolean.parseBoolean(value.toString()));
+            }
+        });
+
+        register(Types.TIMESTAMP, (appender, value) -> {
+            switch (value) {
+                case null -> appender.append((LocalDateTime) null);
+                case Timestamp ts -> appender.append(ts.toLocalDateTime());
+                case LocalDateTime ldt -> appender.append(ldt);
+                case Date date -> appender.append(DateUtils.toLocalDateTime(date));
+                default -> {
+                    String valStr = value.toString();
+                    LocalDateTime parsed = null;
+
+                    // 尝试默认格式 yyyy-MM-dd HH:mm:ss
+                    try {
+                        parsed = DateUtils.parseLocalDateTime(valStr);
+                    } catch (Exception ignored) {
+                        // ignore
+                    }
+
+                    if (parsed == null) {
+                        // 尝试其他格式
+                        String[] patterns = {
+                                "yyyy/MM/dd HH:mm:ss",
+                                DateUtils.NORM_DATE_PATTERN,
+                                "yyyy-MM-dd'T'HH:mm:ss",
+                                "yyyy-MM-dd'T'HH:mm:ss.SSS"
+                        };
+                        for (String pattern : patterns) {
+                            try {
+                                parsed = DateUtils.parseLocalDateTime(valStr, pattern);
+                                break;
+                            } catch (Exception ignored) {
+                                // ignore
+                            }
+                        }
+                    }
+
+                    if (parsed != null) {
+                        appender.append(parsed);
+                    } else {
+                        try {
+                            appender.append(Timestamp.valueOf(valStr).toLocalDateTime());
+                        } catch (Exception e) {
+                            throw new SQLException("无法将值 '" + value + "' 解析为 TIMESTAMP", e);
+                        }
+                    }
+                }
+            }
+        });
+        
+        register(Types.VARCHAR, (appender, value) -> appender.append(value == null ? null : value.toString()));
+        register(Types.CHAR, (appender, value) -> appender.append(value == null ? null : value.toString()));
+        register(Types.LONGVARCHAR, (appender, value) -> appender.append(value == null ? null : value.toString()));
+    }
+
+    public static void register(int sqlType, TypeHandler handler) {
+        HANDLERS.put(sqlType, handler);
+    }
+
+    public static TypeHandler getHandler(int sqlType) {
+        return HANDLERS.getOrDefault(sqlType, DEFAULT_HANDLER);
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/DuckDbExtensionTest.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/DuckDbExtensionTest.java
@@ -1,0 +1,49 @@
+package cn.fxbin.bubble.data.duckdb;
+
+import cn.fxbin.bubble.data.duckdb.autoconfigure.DuckDbAutoConfiguration;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbTemplate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * DuckDB Extension Test
+ *
+ * @author fxbin
+ * @version v1.0
+ * @since 2025/12/08 16:00
+ */
+@SpringBootTest(classes = DuckDbAutoConfiguration.class)
+@TestPropertySource(properties = {
+    "dm.data.duckdb.mode=MEMORY",
+    "dm.data.duckdb.extensions[0]=json",
+    "dm.data.duckdb.auto-install-extensions=true"
+})
+public class DuckDbExtensionTest {
+
+    @Autowired
+    private DuckDbTemplate duckDbTemplate;
+
+    @Test
+    void testJsonExtension() {
+        // This query requires the json extension
+        // Note: json_extract returns a JSON type, which JDBC driver maps to String
+        String sql = "SELECT json_extract('{\"foo\": \"bar\"}', '$.foo') as result";
+        
+        List<Map<String, Object>> result = duckDbTemplate.queryForList(sql);
+        
+        assertThat(result).hasSize(1);
+        // The result of json_extract('{"foo": "bar"}', '$.foo') is '"bar"' (with quotes) because it's a JSON string.
+        // If we used json_extract_string, it would be 'bar'.
+        // Let's check what we get.
+        Object val = result.get(0).get("result");
+        assertThat(val).isNotNull();
+        System.out.println("JSON Extract Result: " + val);
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/DuckDbPerformanceTest.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/DuckDbPerformanceTest.java
@@ -1,0 +1,380 @@
+package cn.fxbin.bubble.data.duckdb;
+
+import cn.fxbin.bubble.data.duckdb.autoconfigure.DuckDbProperties;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbIngester;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbManager;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbTemplate;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * DuckDB 性能测试 (IoT 场景)
+ *
+ * <p>
+ * 测试 100 列 IoT 数据的高性能写入和查询。
+ * </p>
+ *
+ * @author fxbin
+ * @version v2.0
+ * @since 2025/12/09
+ */
+@Slf4j
+public class DuckDbPerformanceTest {
+
+    private DuckDbManager duckDbManager;
+    private DuckDbOperations duckDbOps;
+    private String dbPath;
+    private String csvPath;
+
+    /**
+     * 测试数据量
+     * 默认 100,000 用于快速验证。
+     */
+    private static final long DATA_COUNT = 100_000L;
+
+    @BeforeEach
+    void setUp() {
+        // 使用临时文件
+        dbPath = "target/duckdb_iot_perf.db";
+        csvPath = "target/iot_data_perf.csv";
+
+        // 清理旧文件
+        try {
+            Files.deleteIfExists(Paths.get(dbPath));
+            Files.deleteIfExists(Paths.get(csvPath));
+        } catch (Exception e) {
+            log.warn("Failed to clean files: {}", e.getMessage());
+        }
+
+        // 初始化 Manager
+        DuckDbProperties properties = new DuckDbProperties();
+        properties.setMode(DuckDbProperties.Mode.FILE);
+        properties.setFilePath(dbPath);
+        properties.setMemoryLimit("2GB");
+
+        duckDbManager = new DuckDbManager(properties);
+        DuckDbTemplate template = duckDbManager.getTemplate(dbPath);
+        DuckDbIngester ingester = new DuckDbIngester(template.getDataSource());
+
+        // 初始化客户端
+        duckDbOps = new DuckDbOperations(template, duckDbManager, ingester);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (duckDbManager != null) {
+            duckDbManager.close();
+        }
+    }
+
+    /**
+     * 核心性能测试: 生成 -> 导入 -> 查询
+     */
+    @Test
+    void testPerformance() throws IOException {
+        // 1. 创建表
+        createTable(duckDbOps.template());
+
+        // 2. 生成 CSV 数据
+        log.info("正在生成 {} 行测试数据 (100 列)...", DATA_COUNT);
+        long start = System.currentTimeMillis();
+        generateCsvData(csvPath, DATA_COUNT);
+        log.info("数据生成完成，耗时: {} ms", System.currentTimeMillis() - start);
+
+        // 3. 导入数据 (COPY 模式)
+        log.info("开始数据导入 (COPY 模式)...");
+        start = System.currentTimeMillis();
+        // 明确指定分隔符为逗号，且无表头
+        String importSql = String.format("COPY iot_data FROM '%s' (DELIMITER ',', HEADER FALSE)", csvPath);
+        duckDbOps.execute(importSql);
+        log.info("COPY 导入完成，耗时: {} ms", System.currentTimeMillis() - start);
+
+        // 4. 执行查询
+        executePerformanceQueries(duckDbOps.template());
+    }
+
+    @Test
+    void testAppenderIngestion() throws IOException {
+        // 独立数据库文件
+        String appenderDbPath = "target/duckdb_appender_iot.db";
+        Path path = Paths.get(appenderDbPath);
+        Files.deleteIfExists(path);
+
+        DuckDbTemplate template = duckDbOps.connect(appenderDbPath);
+        createTable(template);
+
+        log.info("开始生成数据流...");
+        // 模拟数据流
+        Iterator<Object[]> dataStream = new Iterator<>() {
+            private long current = 0;
+
+            @Override
+            public boolean hasNext() {
+                return current < DATA_COUNT;
+            }
+
+            @Override
+            public Object[] next() {
+                current++;
+                return generateRowData(current);
+            }
+        };
+
+        log.info("开始数据导入 (Appender 模式)...");
+        long start = System.currentTimeMillis();
+
+        template.append("iot_data", dataStream);
+
+        log.info("Appender 导入完成，耗时: {} ms", System.currentTimeMillis() - start);
+
+        // 验证
+        Long count = template.queryForObject("SELECT COUNT(*) FROM iot_data", Long.class);
+        log.info("导入后计数: {}", count);
+        if (count != DATA_COUNT) {
+            throw new RuntimeException("Data count mismatch!");
+        }
+    }
+
+    private void createTable(DuckDbTemplate template) {
+        template.execute("DROP TABLE IF EXISTS iot_data");
+        StringBuilder sql = new StringBuilder("CREATE TABLE iot_data (\n");
+
+        // 1. ID (PK)
+        sql.append("    id VARCHAR PRIMARY KEY,\n");
+
+        // 2-10: 设备信息 (9 cols)
+        sql.append("    device_id VARCHAR,\n");
+        sql.append("    device_type VARCHAR,\n");
+        sql.append("    vendor VARCHAR,\n");
+        sql.append("    model VARCHAR,\n");
+        sql.append("    firmware_ver VARCHAR,\n");
+        sql.append("    serial_no VARCHAR,\n");
+        sql.append("    batch_no VARCHAR,\n");
+        sql.append("    purchase_date TIMESTAMP,\n");
+        sql.append("    warranty_expire TIMESTAMP,\n");
+
+        // 11-20: 位置信息 (10 cols)
+        sql.append("    location_lat DOUBLE,\n");
+        sql.append("    location_lon DOUBLE,\n");
+        sql.append("    location_alt DOUBLE,\n");
+        sql.append("    region_code VARCHAR,\n");
+        sql.append("    city VARCHAR,\n");
+        sql.append("    zone_id VARCHAR,\n");
+        sql.append("    building_id VARCHAR,\n");
+        sql.append("    floor_id VARCHAR,\n");
+        sql.append("    room_id VARCHAR,\n");
+        sql.append("    placement VARCHAR,\n");
+
+        // 21-30: 状态信息 (10 cols)
+        sql.append("    status VARCHAR,\n");
+        sql.append("    online BOOLEAN,\n");
+        sql.append("    battery_level INTEGER,\n");
+        sql.append("    signal_dbm INTEGER,\n");
+        sql.append("    ip_address VARCHAR,\n");
+        sql.append("    mac_address VARCHAR,\n");
+        sql.append("    last_boot TIMESTAMP,\n");
+        sql.append("    uptime_seconds BIGINT,\n");
+        sql.append("    error_code INTEGER,\n");
+        sql.append("    warning_level INTEGER,\n");
+
+        // 31-90: 传感器数据 (60 cols)
+        for (int i = 1; i <= 20; i++) sql.append(String.format("    temp_%02d DOUBLE,\n", i));
+        for (int i = 1; i <= 10; i++) sql.append(String.format("    humid_%02d DOUBLE,\n", i));
+        for (int i = 1; i <= 10; i++) sql.append(String.format("    press_%02d DOUBLE,\n", i));
+        for (int i = 1; i <= 10; i++) sql.append(String.format("    vib_%02d DOUBLE,\n", i));
+        for (int i = 1; i <= 10; i++) sql.append(String.format("    elec_%02d DOUBLE,\n", i));
+
+        // 91-100: 元数据 (10 cols)
+        sql.append("    data_quality INTEGER,\n");
+        sql.append("    processed BOOLEAN,\n");
+        sql.append("    tags VARCHAR,\n");
+        sql.append("    notes VARCHAR,\n");
+        sql.append("    operator VARCHAR,\n");
+        sql.append("    maintenance_due TIMESTAMP,\n");
+        sql.append("    config_hash VARCHAR,\n");
+        sql.append("    tenant_id VARCHAR,\n");
+        sql.append("    created_at TIMESTAMP,\n");
+        sql.append("    updated_at TIMESTAMP\n");
+
+        sql.append(");");
+
+        template.execute(sql.toString());
+        log.info("表 'iot_data' 创建成功，包含 100 列。");
+        
+        // 创建索引
+        template.execute("CREATE INDEX idx_device_id ON iot_data(device_id)");
+        template.execute("CREATE INDEX idx_created_at ON iot_data(created_at)");
+        template.execute("CREATE INDEX idx_location ON iot_data(city, region_code)");
+        log.info("索引创建成功。");
+    }
+
+    private Object[] generateRowData(long i) {
+        Object[] row = new Object[100];
+        int col = 0;
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        // 1. ID
+        row[col++] = randomString(16);
+
+        // 2-10: 设备信息
+        row[col++] = "DEV_" + random.nextInt(1, 1000); // device_id
+        row[col++] = randomEle(new String[]{"Sensor", "Gateway", "Robot", "Camera"}); // device_type
+        row[col++] = "Vendor_" + (char)('A' + random.nextInt(26)); // vendor
+        row[col++] = "Model_" + random.nextInt(1, 10); // model
+        row[col++] = "v" + random.nextInt(1, 5) + "." + random.nextInt(0, 9); // firmware
+        row[col++] = randomString(10); // serial
+        row[col++] = "BATCH-" + (2020 + random.nextInt(0, 5)); // batch
+        row[col++] = LocalDateTime.now().minusDays(random.nextInt(0, 1000)); // purchase
+        row[col++] = LocalDateTime.now().plusDays(random.nextInt(0, 1000)); // warranty
+
+        // 11-20: 位置信息
+        row[col++] = random.nextDouble(20.0, 50.0); // lat
+        row[col++] = random.nextDouble(100.0, 130.0); // lon
+        row[col++] = random.nextDouble(0.0, 100.0); // alt
+        row[col++] = "CN"; // region
+        row[col++] = randomEle(new String[]{"Beijing", "Shanghai", "Shenzhen", "Hangzhou"}); // city
+        row[col++] = "Z" + random.nextInt(1, 10); // zone
+        row[col++] = "B" + random.nextInt(1, 20); // building
+        row[col++] = "F" + random.nextInt(1, 50); // floor
+        row[col++] = "R" + random.nextInt(101, 999); // room
+        row[col++] = randomEle(new String[]{"Ceiling", "Wall", "Floor"}); // placement
+
+        // 21-30: 状态信息
+        row[col++] = randomEle(new String[]{"Active", "Standby", "Error", "Maintenance"}); // status
+        row[col++] = random.nextBoolean(); // online
+        row[col++] = random.nextInt(0, 100); // battery
+        row[col++] = random.nextInt(-100, -30); // signal
+        row[col++] = "192.168." + random.nextInt(0, 255) + "." + random.nextInt(0, 255); // ip
+        row[col++] = randomString(12); // mac
+        row[col++] = LocalDateTime.now().minusHours(random.nextInt(0, 100)); // last_boot
+        row[col++] = random.nextLong(0, 1000000); // uptime
+        row[col++] = random.nextInt(0, 5); // error_code
+        row[col++] = random.nextInt(0, 3); // warning_level
+
+        // 31-90: 传感器数据 (60 cols)
+        for (int k = 0; k < 20; k++) row[col++] = random.nextDouble(20.0, 80.0);
+        for (int k = 0; k < 10; k++) row[col++] = random.nextDouble(30.0, 90.0);
+        for (int k = 0; k < 10; k++) row[col++] = random.nextDouble(900.0, 1100.0);
+        for (int k = 0; k < 10; k++) row[col++] = random.nextDouble(0.0, 5.0);
+        for (int k = 0; k < 10; k++) row[col++] = random.nextDouble(210.0, 230.0);
+
+        // 91-100: 元数据
+        row[col++] = random.nextInt(1, 10); // quality
+        row[col++] = random.nextBoolean(); // processed
+        // 注意：CSV 中使用逗号作为分隔符，所以数据中不能包含逗号，或者需要转义。
+        // 这里为了简单，将 tag 分隔符改为分号。
+        row[col++] = "tag1;tag2"; // tags
+        row[col++] = "Routine check"; // notes
+        row[col++] = "Admin"; // operator
+        row[col++] = LocalDateTime.now().plusMonths(3); // maintenance
+        row[col++] = randomString(8); // hash
+        row[col++] = "T-" + random.nextInt(100, 200); // tenant
+        row[col++] = LocalDateTime.now().minusSeconds(random.nextInt(0, 3600)); // created_at
+        row[col++] = LocalDateTime.now(); // updated_at
+
+        return row;
+    }
+
+    private String randomString(int length) {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        StringBuilder sb = new StringBuilder(length);
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int i = 0; i < length; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        return sb.toString();
+    }
+    
+    private <T> T randomEle(T[] array) {
+        if (array == null || array.length == 0) return null;
+        return array[ThreadLocalRandom.current().nextInt(array.length)];
+    }
+
+    private void generateCsvData(String path, long count) throws IOException {
+        Path filePath = Paths.get(path);
+        if (filePath.getParent() != null) {
+            Files.createDirectories(filePath.getParent());
+        }
+
+        try (BufferedWriter writer = Files.newBufferedWriter(filePath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            for (long i = 0; i < count; i++) {
+                Object[] rowData = generateRowData(i);
+                List<String> csvRow = new ArrayList<>(100);
+                for (Object val : rowData) {
+                    if (val == null) {
+                        csvRow.add("");
+                    } else if (val instanceof LocalDateTime) {
+                        csvRow.add(((LocalDateTime) val).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+                    } else {
+                        csvRow.add(String.valueOf(val));
+                    }
+                }
+                writer.write(String.join(",", csvRow));
+                writer.newLine();
+
+                if (i % 50000 == 0 && i > 0) {
+                    log.info("已生成 {} 行...", i);
+                }
+            }
+        }
+    }
+
+    private void executePerformanceQueries(DuckDbTemplate template) {
+        log.info("=== 开始执行性能查询 ===");
+
+        // 1. 计数
+        runQuery(template, "1. 总数统计", "SELECT COUNT(*) FROM iot_data");
+
+        // 2. 分组
+        runQuery(template, "2. 设备类型统计", 
+            "SELECT device_type, COUNT(*) as cnt, AVG(temp_01) as avg_temp FROM iot_data GROUP BY device_type ORDER BY cnt DESC");
+
+        // 3. 过滤 + 排序 (走索引)
+        runQuery(template, "3. 最近告警 (索引)", 
+            "SELECT device_id, created_at, error_code FROM iot_data WHERE error_code > 0 ORDER BY created_at DESC LIMIT 100");
+
+        // 4. 复杂过滤 (非索引)
+        runQuery(template, "4. 高温低电量 (全表扫描)", 
+            "SELECT device_id, temp_01, battery_level FROM iot_data WHERE temp_01 > 75.0 AND battery_level < 20 LIMIT 100");
+
+        // 5. 多列聚合
+        runQuery(template, "5. 传感器平均值", 
+            "SELECT AVG(temp_01), AVG(humid_01), AVG(press_01), AVG(vib_01), AVG(elec_01) FROM iot_data");
+
+        // 6. 分页
+        runQuery(template, "6. 分页查询 (Offset 50000)", 
+            "SELECT device_id, created_at FROM iot_data ORDER BY created_at LIMIT 100 OFFSET 50000");
+        
+        // 7. 窗口函数
+        runQuery(template, "7. 窗口函数 (排名)",
+            "SELECT device_id, temp_01, RANK() OVER (PARTITION BY device_type ORDER BY temp_01 DESC) as rank FROM iot_data LIMIT 100");
+
+        log.info("=== 性能测试结束 ===");
+    }
+
+    private void runQuery(DuckDbTemplate template, String name, String sql) {
+        try {
+            long start = System.currentTimeMillis();
+            template.execute(sql);
+            long cost = System.currentTimeMillis() - start;
+            log.info("[{}] 耗时: {} ms | SQL: {}", name, cost, sql);
+        } catch (Exception e) {
+            log.error("[{}] 失败: {}", name, e.getMessage());
+        }
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/autoconfigure/DuckDbAutoConfigurationTest.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/autoconfigure/DuckDbAutoConfigurationTest.java
@@ -1,0 +1,59 @@
+package cn.fxbin.bubble.data.duckdb.autoconfigure;
+
+import cn.fxbin.bubble.data.duckdb.DuckDbOperations;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DuckDbAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(DuckDbAutoConfiguration.class));
+
+    @Test
+    void shouldNotLoadWhenDisabled() {
+        contextRunner
+                .withPropertyValues("dm.data.duckdb.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(DuckDbOperations.class);
+                    assertThat(context).doesNotHaveBean("duckDbDataSource");
+                });
+    }
+
+    @Test
+    void shouldCreateBeansAndOperateOnDatabase(@TempDir Path tempDir) {
+        Path dbPath = tempDir.resolve("test.duckdb");
+        contextRunner
+                .withPropertyValues(
+                        "dm.data.duckdb.enabled=true",
+                        "dm.data.duckdb.mode=FILE",
+                        "dm.data.duckdb.file-path=" + dbPath,
+                        "dm.data.duckdb.maximum-pool-size=2"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(DuckDbOperations.class);
+                    assertThat(context).hasBean("duckDbDataSource");
+
+                    Object ds = context.getBean("duckDbDataSource");
+                    assertThat(ds).isInstanceOf(HikariDataSource.class);
+                    HikariDataSource hikari = (HikariDataSource) ds;
+                    assertThat(hikari.getJdbcUrl()).contains("jdbc:duckdb:");
+
+                    DuckDbOperations ops = context.getBean(DuckDbOperations.class);
+                    ops.execute("CREATE TABLE users (id BIGINT, name VARCHAR)");
+                    ops.execute("INSERT INTO users VALUES (1, 'Alice'), (2, 'Bob')");
+                    Long count = ops.count("users");
+                    assertThat(count).isEqualTo(2L);
+
+                    assertThatThrownBy(() -> ops.count("users; DROP TABLE users"))
+                            .isInstanceOf(IllegalArgumentException.class);
+                });
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/benchmark/WideTableBenchmarkTest.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/benchmark/WideTableBenchmarkTest.java
@@ -1,0 +1,175 @@
+package cn.fxbin.bubble.data.duckdb.benchmark;
+
+import cn.fxbin.bubble.data.duckdb.autoconfigure.DuckDbProperties;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbConnectionFactory;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbIngester;
+import cn.fxbin.bubble.data.duckdb.core.DuckDbTemplate;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.util.StopWatch;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Iterator;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * DuckDB 宽表性能基准测试
+ *
+ * @author fxbin
+ * @since 2025/12/17
+ */
+@Slf4j
+public class WideTableBenchmarkTest {
+
+    private HikariDataSource dataSource;
+    private DuckDbTemplate template;
+    private DuckDbIngester ingester;
+
+    // 配置参数
+    private static final int COLUMN_COUNT = 2000;
+    private static final int ROW_COUNT = 10_000; // 1万行 * 2000列 = 2000万个数据点
+    private static final String TABLE_NAME = "wide_table_benchmark";
+
+    @BeforeEach
+    void setUp(@TempDir Path tempDir) {
+        DuckDbProperties properties = new DuckDbProperties();
+        // 使用文件模式以模拟真实 I/O，并设置合理的内存限制
+        properties.setMode(DuckDbProperties.Mode.FILE);
+        properties.setFilePath(tempDir.resolve("benchmark.duckdb").toString());
+        properties.setMemoryLimit("4GB"); // 给足内存
+        properties.setThreads("4");
+
+        DuckDbConnectionFactory factory = new DuckDbConnectionFactory(properties);
+        dataSource = factory.createDefaultDataSource();
+        template = new DuckDbTemplate(dataSource);
+        ingester = new DuckDbIngester(dataSource);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+
+    @Test
+    void benchmarkWideTableIngestAndQuery() {
+        log.info("开始宽表性能测试：列数={}, 行数={}", COLUMN_COUNT, ROW_COUNT);
+
+        // 1. 创建宽表
+        createWideTable();
+
+        // 2. 准备数据生成器
+        Iterator<Object[]> dataIterator = new WideTableDataIterator(ROW_COUNT, COLUMN_COUNT);
+
+        // 3. 执行写入测试
+        StopWatch stopWatch = new StopWatch("DuckDB Benchmark");
+        stopWatch.start("Ingest " + ROW_COUNT + " rows");
+        
+        ingester.ingest(TABLE_NAME, dataIterator, 2000); // 每 2000 行打一次日志
+        
+        stopWatch.stop();
+        log.info("写入完成。耗时: {} ms, 吞吐量: {} rows/sec", 
+                stopWatch.getLastTaskTimeMillis(), 
+                (double) ROW_COUNT / stopWatch.getLastTaskTimeMillis() * 1000);
+
+        // 4. 验证行数
+        Long count = template.queryForObject("SELECT count(*) FROM " + TABLE_NAME, Long.class);
+        assertThat(count).isEqualTo(ROW_COUNT);
+
+        // 5. 执行查询测试 - 全表聚合
+        stopWatch.start("Query Aggregation (COUNT)");
+        template.queryForObject("SELECT count(*) FROM " + TABLE_NAME, Long.class);
+        stopWatch.stop();
+        
+        // 6. 执行查询测试 - 特定列过滤与聚合 (模拟业务查询)
+        // 查询 col_1 (DOUBLE 类型) 的平均值，过滤 col_0 > 0
+        stopWatch.start("Query Complex Aggregation");
+        // col_1 是 DOUBLE 类型，适合做聚合测试
+        String querySql = "SELECT avg(col_1) FROM " + TABLE_NAME + " WHERE col_0 > 0";
+        Double avg = template.queryForObject(querySql, Double.class);
+        stopWatch.stop();
+        log.info("查询结果 (AVG col_1): {}", avg);
+
+        log.info(stopWatch.prettyPrint());
+    }
+
+    private void createWideTable() {
+        StringBuilder sql = new StringBuilder("CREATE TABLE " + TABLE_NAME + " (");
+        
+        // 为了模拟真实场景，我们使用混合类型
+        // col_0: BIGINT (ID)
+        // col_1...N: 循环使用 INTEGER, DOUBLE, VARCHAR, TIMESTAMP
+        
+        sql.append("col_0 BIGINT");
+
+        for (int i = 1; i < COLUMN_COUNT; i++) {
+            sql.append(", ");
+            sql.append("col_").append(i).append(" ");
+            
+            int typeMod = i % 4;
+            switch (typeMod) {
+                case 0 -> sql.append("INTEGER");
+                case 1 -> sql.append("DOUBLE");
+                case 2 -> sql.append("VARCHAR");
+                case 3 -> sql.append("TIMESTAMP");
+            }
+        }
+        sql.append(")");
+        
+        long start = System.currentTimeMillis();
+        template.execute(sql.toString());
+        log.info("建表完成。耗时: {} ms", System.currentTimeMillis() - start);
+    }
+
+    /**
+     * 宽表数据生成器
+     */
+    static class WideTableDataIterator implements Iterator<Object[]> {
+        private final int totalRows;
+        private final int totalCols;
+        private final AtomicInteger currentRow = new AtomicInteger(0);
+        private final Random random = new Random();
+        private final LocalDateTime now = LocalDateTime.now();
+
+        public WideTableDataIterator(int totalRows, int totalCols) {
+            this.totalRows = totalRows;
+            this.totalCols = totalCols;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return currentRow.get() < totalRows;
+        }
+
+        @Override
+        public Object[] next() {
+            int rowId = currentRow.getAndIncrement();
+            Object[] row = new Object[totalCols];
+            
+            // col_0 is ID
+            row[0] = (long) rowId;
+
+            for (int i = 1; i < totalCols; i++) {
+                int typeMod = i % 4;
+                switch (typeMod) {
+                    case 0 -> row[i] = rowId + i; // INTEGER
+                    case 1 -> row[i] = (double) rowId * i / 100.0; // DOUBLE
+                    case 2 -> row[i] = "str_" + rowId + "_" + i; // VARCHAR
+                    case 3 -> row[i] = now.plusSeconds(rowId); // TIMESTAMP
+                }
+            }
+            return row;
+        }
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/core/DuckDbConnectionFactoryTest.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/core/DuckDbConnectionFactoryTest.java
@@ -1,0 +1,76 @@
+package cn.fxbin.bubble.data.duckdb.core;
+
+import cn.fxbin.bubble.data.duckdb.autoconfigure.DuckDbProperties;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DuckDbConnectionFactoryTest {
+
+    @Test
+    void shouldBuildJdbcUrlFromFileMode(@TempDir Path tempDir) {
+        DuckDbProperties properties = new DuckDbProperties();
+        properties.setMode(DuckDbProperties.Mode.FILE);
+        properties.setFilePath(tempDir.resolve("db.duckdb").toString());
+        properties.setReadOnly(true);
+        properties.setMaximumPoolSize(3);
+        properties.setMemoryLimit("2GB");
+        properties.setThreads("2");
+        properties.setTempDirectory(tempDir.resolve("tmp").toString());
+
+        DuckDbConnectionFactory factory = new DuckDbConnectionFactory(properties);
+        HikariDataSource ds = factory.createDefaultDataSource();
+
+        assertThat(ds.getJdbcUrl()).contains("jdbc:duckdb:").contains("duckdb.read_only=true");
+        assertThat(ds.getMaximumPoolSize()).isEqualTo(3);
+        assertThat(ds.getDataSourceProperties())
+                .containsEntry("memory_limit", "2GB")
+                .containsEntry("threads", "2")
+                .containsEntry("temp_directory", properties.getTempDirectory())
+                .containsEntry("preserve_insertion_order", "false");
+
+        ds.close();
+    }
+
+    @Test
+    void shouldUseCustomJdbcUrlWhenProvided() {
+        DuckDbProperties properties = new DuckDbProperties();
+        properties.setUrl("jdbc:duckdb:");
+
+        DuckDbConnectionFactory factory = new DuckDbConnectionFactory(properties);
+        HikariDataSource ds = factory.createDefaultDataSource();
+
+        assertThat(ds.getJdbcUrl()).isEqualTo("jdbc:duckdb:");
+        ds.close();
+    }
+
+    @Test
+    void shouldSetConnectionInitSqlForExtensions() {
+        DuckDbProperties properties = new DuckDbProperties();
+        properties.setMode(DuckDbProperties.Mode.MEMORY);
+        properties.setExtensions(List.of("json"));
+
+        DuckDbConnectionFactory factory = new DuckDbConnectionFactory(properties);
+        HikariDataSource ds = factory.createDefaultDataSource();
+
+        assertThat(ds.getConnectionInitSql()).contains("LOAD json");
+        ds.close();
+    }
+
+    @Test
+    void shouldFailWhenFileModeWithoutFilePath() {
+        DuckDbProperties properties = new DuckDbProperties();
+        properties.setMode(DuckDbProperties.Mode.FILE);
+        properties.setFilePath(" ");
+
+        DuckDbConnectionFactory factory = new DuckDbConnectionFactory(properties);
+        assertThatThrownBy(factory::createDefaultDataSource)
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/core/DuckDbIngesterTest.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/core/DuckDbIngesterTest.java
@@ -1,0 +1,84 @@
+package cn.fxbin.bubble.data.duckdb.core;
+
+import cn.fxbin.bubble.data.duckdb.autoconfigure.DuckDbProperties;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DuckDbIngesterTest {
+
+    private HikariDataSource dataSource;
+
+    @AfterEach
+    void tearDown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+
+    @Test
+    void shouldIngestRowsWithAppender() {
+        DuckDbProperties properties = new DuckDbProperties();
+        properties.setMode(DuckDbProperties.Mode.MEMORY);
+        properties.setMaximumPoolSize(1);
+
+        DuckDbConnectionFactory factory = new DuckDbConnectionFactory(properties);
+        dataSource = factory.createDefaultDataSource();
+
+        DuckDbTemplate template = new DuckDbTemplate(dataSource);
+        template.execute("CREATE TABLE events (id BIGINT, name VARCHAR, created_at TIMESTAMP)");
+
+        DuckDbIngester ingester = new DuckDbIngester(dataSource);
+        ingester.append("events", List.<Object[]>of(
+                new Object[]{1L, "A", LocalDateTime.of(2025, 12, 17, 12, 0, 0)},
+                new Object[]{2L, "B", "2025-12-17 13:00:00"}
+        ));
+
+        Long count = template.queryForObject("SELECT count(*) FROM events", Long.class);
+        assertThat(count).isEqualTo(2L);
+    }
+
+    @Test
+    void shouldFailOnColumnCountMismatch() {
+        DuckDbProperties properties = new DuckDbProperties();
+        properties.setMode(DuckDbProperties.Mode.MEMORY);
+        properties.setMaximumPoolSize(1);
+
+        DuckDbConnectionFactory factory = new DuckDbConnectionFactory(properties);
+        dataSource = factory.createDefaultDataSource();
+
+        DuckDbTemplate template = new DuckDbTemplate(dataSource);
+        template.execute("CREATE TABLE t (id BIGINT, name VARCHAR)");
+
+        DuckDbIngester ingester = new DuckDbIngester(dataSource);
+        assertThatThrownBy(() -> ingester.append("t", List.<Object[]>of(new Object[]{1L})))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void shouldExportParquetWhenPathContainsSingleQuote(@TempDir Path tempDir) {
+        DuckDbProperties properties = new DuckDbProperties();
+        properties.setMode(DuckDbProperties.Mode.MEMORY);
+        properties.setMaximumPoolSize(1);
+
+        DuckDbConnectionFactory factory = new DuckDbConnectionFactory(properties);
+        dataSource = factory.createDefaultDataSource();
+
+        DuckDbTemplate template = new DuckDbTemplate(dataSource);
+        template.execute("CREATE TABLE t (id BIGINT)");
+        template.execute("INSERT INTO t VALUES (1)");
+
+        Path output = tempDir.resolve("a'b.parquet");
+        template.exportParquet("t", output.toString());
+
+        assertThat(output).exists();
+    }
+}

--- a/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/core/DuckDbManagerTest.java
+++ b/bubble-starters/bubble-starter-data-duckdb/src/test/java/cn/fxbin/bubble/data/duckdb/core/DuckDbManagerTest.java
@@ -1,0 +1,44 @@
+package cn.fxbin.bubble.data.duckdb.core;
+
+import cn.fxbin.bubble.data.duckdb.autoconfigure.DuckDbProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DuckDbManagerTest {
+
+    private DuckDbManager manager;
+
+    @AfterEach
+    void tearDown() {
+        if (manager != null) {
+            manager.close();
+        }
+    }
+
+    @Test
+    void shouldCacheTemplatesByPathAndMode(@TempDir Path tempDir) {
+        DuckDbProperties properties = new DuckDbProperties();
+        properties.setMode(DuckDbProperties.Mode.FILE);
+        properties.setFilePath(tempDir.resolve("default.duckdb").toString());
+
+        manager = new DuckDbManager(properties);
+
+        String path = tempDir.resolve("a.duckdb").toString();
+        DuckDbTemplate rw1 = manager.getTemplate(path, false);
+        DuckDbTemplate rw2 = manager.getTemplate(path, false);
+        DuckDbTemplate ro = manager.getTemplate(path, true);
+
+        assertThat(rw1).isSameAs(rw2);
+        assertThat(ro).isNotSameAs(rw1);
+
+        rw1.execute("CREATE TABLE t (id BIGINT)");
+        Long count = rw1.queryForObject("SELECT count(*) FROM t", Long.class);
+        assertThat(count).isEqualTo(0L);
+    }
+}
+

--- a/bubble-starters/pom.xml
+++ b/bubble-starters/pom.xml
@@ -24,6 +24,7 @@
         <module>bubble-starter-test</module>
         <!-- data -->
         <module>bubble-starter-data-redis</module>
+        <module>bubble-starter-data-duckdb</module>
         <module>bubble-starter-data-mybatis-plus</module>
         <module>bubble-starter-data-elasticsearch</module>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,9 +50,9 @@ flowchart TB
     subgraph starters
       E1[bubble-starter-web]
       E2[bubble-starter-data-redis]
-      E3[bubble-starter-data-mybatis-plus]
-      E4[bubble-starter-data-elasticsearch]
-      E5[bubble-starter-openfeign]
+      E3[bubble-starter-data-duckdb]
+      E4[bubble-starter-data-mybatis-plus]
+      E5[bubble-starter-data-elasticsearch]
       E6[bubble-starter-dubbo]
       E7[bubble-starter-satoken]
       E8[bubble-starter-logging]

--- a/docs/starter-modules.md
+++ b/docs/starter-modules.md
@@ -3,8 +3,8 @@
 Bubble 提供 15+ Starter，以 AutoConfiguration + Properties 的方式输出能力：
 
 - Web：`bubble-starter-web`
-- 数据：`bubble-starter-data-redis`、`bubble-starter-data-mybatis-plus`、`bubble-starter-data-elasticsearch`
-- RPC：`bubble-starter-openfeign`、`bubble-starter-dubbo`
+- 数据：`bubble-starter-data-redis`、`bubble-starter-data-duckdb`、`bubble-starter-data-mybatis-plus`、`bubble-starter-data-elasticsearch`
+- RPC：`bubble-starter-dubbo`
 - 安全：`bubble-starter-satoken`
 - 运行：`bubble-starter-logging`、`bubble-starter-lock`、`bubble-starter-mail`、`bubble-starter-excel`、`bubble-starter-i18n`、`bubble-starter-xxl-job`、`bubble-starter-test`
 
@@ -12,9 +12,9 @@ Bubble 提供 15+ Starter，以 AutoConfiguration + Properties 的方式输出�
 
 - [web](starters/web.md)
 - [data-redis](starters/data-redis.md)
+- [data-duckdb](starters/data-duckdb.md)
 - [data-mybatis-plus](starters/data-mybatis-plus.md)
 - [data-elasticsearch](starters/data-elasticsearch.md)
-- [openfeign](starters/openfeign.md)
 - [dubbo](starters/dubbo.md)
 - [satoken](starters/satoken.md)
 - [logging](starters/logging.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,9 +3,8 @@
 ## 常见场景食谱
 
 - 认证与授权：`starters/satoken.md`
-- 远程调用：`starters/openfeign.md`
-- 缓存与数据：`starters/data-redis.md`、`starters/data-mybatis-plus.md`
+- 远程调用：`starters/dubbo.md`
+- 缓存与数据：`starters/data-redis.md`、`starters/data-duckdb.md`、`starters/data-mybatis-plus.md`
 - 日志治理：`starters/logging.md`
 - 国际化：`starters/i18n.md`
 - 任务调度：`starters/xxl-job.md`
-


### PR DESCRIPTION
- 新增 DuckDB 自动配置类，支持内存与文件模式
- 提供 DuckDbOperations 统一操作入口
- 实现高性能数据摄取器 DuckDbIngester
- 支持动态多数据源管理 DuckDbManager
- 内置 Parquet 导入导出功能
- 添加完整的单元测试与集成测试
- 更新文档说明默认配置与使用方式